### PR TITLE
Remove feature question_mark

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(question_mark)]
-
 extern crate termion;
 
 use termion::{style, cursor, clear};


### PR DESCRIPTION
This feature is now in Rust stable, so adding !#[feature(question_mark)] is now useless and causes a warning.
